### PR TITLE
[SPSCQueue] limit the idx value

### DIFF
--- a/SPSCQueue.h
+++ b/SPSCQueue.h
@@ -42,7 +42,7 @@ public:
     }
 
     void push() {
-      ((std::atomic<uint32_t>*)&write_idx)->store(write_idx + 1, std::memory_order_release);
+      ((std::atomic<uint32_t>*)&write_idx)->store((write_idx + 1) % CNT, std::memory_order_release);
     }
 
     template<typename Writer>
@@ -68,7 +68,7 @@ public:
     }
 
     void pop() {
-      ((std::atomic<uint32_t>*)&read_idx)->store(read_idx + 1, std::memory_order_release);
+      ((std::atomic<uint32_t>*)&read_idx)->store((read_idx + 1) % CNT, std::memory_order_release);
     }
 
     template<typename Reader>


### PR DESCRIPTION
When the reader/writed index pointer is increased, limit the value to
the maximum queue size making a queue circular.

Signed-off-by: Pavel Nadein <pavel.nadein@cpp.canon>